### PR TITLE
Add HowLongToBeat support (closes #19)

### DIFF
--- a/source/Constants.xaml
+++ b/source/Constants.xaml
@@ -114,4 +114,9 @@
         <Color x:Key="RareGlow">#ffdb4d</Color>
         <Color x:Key="NoCommonGlow">#e6ebf0</Color>
 
+        <!-- HowLongToBeat Colors -->
+        <SolidColorBrush x:Key="HLTBMainStoryBrush" Color="#6ab4f1" />
+        <SolidColorBrush x:Key="HLTBMainExtraBrush" Color="#8be59d" />
+        <SolidColorBrush x:Key="HLTBCompletionistBrush" Color="#ec8a83" />
+
 </ResourceDictionary>

--- a/source/Options.yaml
+++ b/source/Options.yaml
@@ -231,3 +231,7 @@ Variables:
     Title: Achievements (Requires SuccessStory)
     Type: Boolean
     Default: true
+  HowLongToBeat:
+    Title: HowLongToBeat
+    Type: Boolean
+    Default: true

--- a/source/Views/GameDetails.xaml
+++ b/source/Views/GameDetails.xaml
@@ -551,6 +551,101 @@
                             </ContentControl.Style>
                         </ContentControl>
 
+                        <!-- HowLongToBeat entry -->
+                        <Border
+                            Grid.Row="0"
+                            Grid.Column="2"
+                            Grid.ColumnSpan="2"
+                            HorizontalAlignment="Right"
+                            VerticalAlignment="Top"
+                            Margin="0,24,0,0"
+                            Background="{DynamicResource GameDetailsBackgroundBrush}"
+                            BorderBrush="{DynamicResource DefaultBorderBrush}"
+                            BorderThickness="1"
+                            CornerRadius="16">
+                            
+                            <Border.Effect>
+                                <DropShadowEffect
+                                    BlurRadius="10"
+                                    Direction="315"
+                                    Opacity="0.5"
+                                    ShadowDepth="5"
+                                    Color="Black" />
+                            </Border.Effect>
+
+                            <StackPanel Margin="32,32,32,22" Orientation="Horizontal">
+                                <StackPanel.Style>
+                                    <Style TargetType="StackPanel">
+                                        <Setter Property="Visibility" Value="Visible" />
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{PluginSettings Plugin=HowLongToBeat, Path=HasData}" Value="False">
+                                                <Setter Property="Visibility" Value="Collapsed" />
+                                            </DataTrigger>
+                                            <DataTrigger Binding="{PluginSettings Plugin=ThemeOptions, Path=Options[HowLongToBeat]}" Value="False">
+                                                <Setter Property="Visibility" Value="Collapsed" />
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </StackPanel.Style>
+                                <TextBlock
+                                    Margin="0,0,12,0"
+                                    Opacity="0.75"
+                                    Style="{StaticResource FluentIconStyle}"
+                                    Text="&#xe916;" />
+                                <StackPanel Margin="0,0,48,0">
+                                    <StackPanel Orientation="Horizontal">
+                                        <TextBlock
+                                            FontFamily="{DynamicResource FontDefaultBold}"
+                                            Style="{DynamicResource TextBlockBaseStyle}"
+                                            Foreground="{DynamicResource HLTBMainStoryBrush}"
+                                            Text="{PluginSettings Plugin=HowLongToBeat,
+                                                                    Path=MainStoryFormat,
+                                                                    FallbackValue='-'}" />
+                                    </StackPanel>
+                                    <TextBlock
+                                        Margin="0,0,0,10"
+                                        FontSize="22"
+                                        Opacity="0.75"
+                                        Style="{DynamicResource TextBlockBaseStyle}"
+                                        Text="{DynamicResource LOCHowLongToBeatMainStory}" />
+                                </StackPanel>
+                                <StackPanel Margin="0,0,48,0">
+                                    <StackPanel Orientation="Horizontal">
+                                        <TextBlock
+                                            FontFamily="{DynamicResource FontDefaultBold}"
+                                            Style="{DynamicResource TextBlockBaseStyle}"
+                                            Foreground="{DynamicResource HLTBMainExtraBrush}"
+                                            Text="{PluginSettings Plugin=HowLongToBeat,
+                                                                    Path=MainExtraFormat,
+                                                                    FallbackValue='-'}" />
+                                    </StackPanel>
+                                    <TextBlock
+                                        Margin="0,0,0,10"
+                                        FontSize="22"
+                                        Opacity="0.75"
+                                        Style="{DynamicResource TextBlockBaseStyle}"
+                                        Text="{DynamicResource LOCHowLongToBeatMainExtra}" />
+                                </StackPanel>
+                                <StackPanel>
+                                    <StackPanel Orientation="Horizontal">
+                                        <TextBlock
+                                            FontFamily="{DynamicResource FontDefaultBold}"
+                                            Style="{DynamicResource TextBlockBaseStyle}"
+                                            Foreground="{DynamicResource HLTBCompletionistBrush}"
+                                            Text="{PluginSettings Plugin=HowLongToBeat,
+                                                                    Path=CompletionistFormat,
+                                                                    FallbackValue='-'}" />
+                                    </StackPanel>
+                                    <TextBlock
+                                        Margin="0,0,0,10"
+                                        FontSize="22"
+                                        Opacity="0.75"
+                                        Style="{DynamicResource TextBlockBaseStyle}"
+                                        Text="{DynamicResource LOCHowLongToBeatCompletionist}" />
+                                </StackPanel>
+                            </StackPanel>
+                        </Border>
+
                         <Border
                             Grid.Row="1"
                             Grid.Column="1"


### PR DESCRIPTION
## Summary
Adds HowLongToBeat.com integration to the Game Details view. The data is displayed in the **top-right corner** of the screen, as this placement offered the best visual balance due to layout constraints.

![Screenshot_20251104_112934_Moonlight](https://github.com/user-attachments/assets/1935d6b4-b8d1-4711-b27b-531a151b3fb8)

## Changes
- Integrated HowLongToBeat data into the Game Details layout
- Displays:
  - Main Story duration
  - Main + Extra duration
  - Completionist duration
- Display toggle added to theme settings
- Added custom **color styling** for HowLongToBeat elements

## Compatibility
- Tested with Playnite 10.43
- Verified on Windows 11

## Notes
- Requires the HowLongToBeat plugin to be installed and configured
- Feature is enabled by default and can be disabled via theme settings

---

Closes #19
